### PR TITLE
Kaminariを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,4 +56,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'slim-rails'
 gem 'html2slim'
 gem 'carrierwave'
+gem 'kaminari'
 gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,18 @@ GEM
       hpricot
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -190,6 +202,7 @@ DEPENDENCIES
   carrierwave
   coffee-rails (~> 4.2)
   html2slim
+  kaminari
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)
   rails (~> 5.2.3)

--- a/app/assets/stylesheets/books.scss
+++ b/app/assets/stylesheets/books.scss
@@ -1,3 +1,7 @@
 // Place all the styles related to the books controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.pagination_bottom {
+  margin-bottom: 1em;
+}

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -3,7 +3,7 @@ class BooksController < ApplicationController
 
   # GET /books
   def index
-    @books = Book.all
+    @books = Book.page(params[:page])
   end
 
   # GET /books/1

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,4 +2,5 @@ class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
   validates :title, presence: true, length: { maximum: 30 }
   validates :memo, presence: true
+  paginates_per 10
 end

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -26,4 +26,8 @@ table
 
 br
 
+.pagination_bottom
+  = paginate @books
+  = page_entries_info @books
+
 = link_to t(".new_book"), new_book_path

--- a/config/locales/kaminari.ja.yml
+++ b/config/locales/kaminari.ja.yml
@@ -1,0 +1,17 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "&hellip;"
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "%{entry_name}がありません"
+          one: "1件の%{entry_name}が表示されています"
+          other: "#{count}件の%{entry_name}が表示されています"
+      more_pages:
+        display_entries: "全%{total}件中 %{first}&nbsp;-&nbsp;%{last}件の%{entry_name}が表示されています"


### PR DESCRIPTION
プラクティス:kaminari を使ってページング処理を実装する の課題を作成しました

## 概要

- gemにkaminariを追加
- ページネーション機能を追加してBookモデルの1ページ毎の表示件数を10件に設定
- i18nに対応

## 確認方法

- 書籍一覧ページにアクセスすると登録された書籍が10件表示される
- ページ下部にページネーションを設置し、各ページのリンクが表示されている
- `page_entries_info`ヘルパーを使って現在のページで全〇〇件中〇〇件が表示されているという情報を表示
- ロケールを切り替えることで表示言語が日本語⇔英語が切り替わる

## スクリーンショット

`http://localhost:3000/ja/books`
![image](https://user-images.githubusercontent.com/37890305/58609004-fc60d380-82e0-11e9-887d-872e400c250c.png)

`http://localhost:3000/en/books`
![image](https://user-images.githubusercontent.com/37890305/58609008-01be1e00-82e1-11e9-87b3-7b66afd51e2b.png)

以上です。確認よろしくおねがいします。