### PR TITLE
ActiveStorageを使って画像のアップロード機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'turbolinks', '~> 5'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
-# gem 'mini_magick', '~> 4.8'
+gem 'mini_magick', '~> 4.8'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
     mimemagic (0.3.3)
+    mini_magick (4.9.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -255,6 +256,7 @@ DEPENDENCIES
   kaminari
   letter_opener_web
   listen (>= 3.0.5, < 3.2)
+  mini_magick (~> 4.8)
   omniauth-github
   puma (~> 3.11)
   rails (~> 5.2.3)

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -163,10 +163,26 @@ textarea {
 }
 
 .user {
+  display: flex;
+  align-items: center;
   flex: 0 0 33%;
   border-bottom: 1px solid #9da4a7;
   margin-right: 1rem;
   padding: 0.5rem 0;
+  width: auto;
+}
+
+.user-image {
+  width: 50px;
+}
+
+
+.form-avatar {
+  display: grid;
+}
+
+.user-info {
+  margin-left: 1rem;
 }
 
 .user-name {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,8 +16,8 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :postcode1, :postcode2, :address, :biography])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :postcode1, :postcode2, :address, :biography])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :postcode1, :postcode2, :address, :biography, :avatar])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :postcode1, :postcode2, :address, :biography, :avatar])
   end
 
   def after_sign_in_path_for(resource)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @users = User.page(params[:page])
+    @users = User.page(params[:page]).with_attached_avatar
   end
 
   def show

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -3,6 +3,7 @@ h1 = t ".book_list"
 table
   thead
     tr
+      th = User.human_attribute_name(:avatar)
       th = Book.human_attribute_name(:title)
       th = Book.human_attribute_name(:memo)
       th = Book.human_attribute_name(:author)
@@ -15,6 +16,7 @@ table
   tbody
     - @books.each do |book|
       tr
+        td = image_tag(book.user.avatar.variant(resize: "50x50")) if book.user.avatar.attached?
         td = book.title
         td = book.memo
         td = book.author

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -7,6 +7,10 @@ h2 = t(".title", resource: resource.model_name.human)
   .field
     = f.label :email
     = f.email_field :email, autocomplete: "email"
+  .field.form-avatar
+    = f.label :avatar
+    = image_tag(resource.avatar.variant(resize: "100x100")) if resource.avatar.attached?
+    = f.file_field :avatar
   .field
     = f.label :postcode
     = f.text_field :postcode1, size: 3, maxlength: 3, id: "user_postcode", placeholder: "111"

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -8,6 +8,9 @@ h2 = t(".sign_up")
     = f.label :email
     = f.email_field :email, autocomplete: "email"
   .field
+    = f.label :avatar
+    = f.file_field :avatar
+  .field
     = f.label :postcode
     = f.text_field :postcode1, size: 3, maxlength: 3, id: "user_postcode", placeholder: "111"
     | -

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -3,6 +3,7 @@ h1 = t(".report_list")
 table
   thead
     tr
+      th = User.human_attribute_name(:avatar)
       th = Report.human_attribute_name(:title)
       th = Report.human_attribute_name(:description)
       th = Report.human_attribute_name(:reported_on)
@@ -14,6 +15,7 @@ table
   tbody
     - @reports.each do |report|
       tr
+        td = image_tag(report.user.avatar.variant(resize: "50x50")) if report.user.avatar.attached?
         td = report.title
         td = truncate("#{report.description}", length: 50)
         td = report.reported_on

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -1,4 +1,7 @@
 .user
-  .user-name = link_to user.name, user_path(user), class: "user-name-link"
-  div = user.email
-  p = truncate(user.biography, length: 200)
+  .user-image
+    = image_tag(user.avatar.variant(resize: "50x50")) if user.avatar.attached?
+  .user-info
+    .user-name = link_to user.name, user_path(user), class: "user-name-link"
+    div = user.email
+    p = truncate(user.biography, length: 200)

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -3,6 +3,9 @@ h1 = t(".profile")
 table
   tbody
     tr
+      th = User.human_attribute_name(:avatar)
+      td = image_tag(@user.avatar.variant(resize: "50x50")) if @user.avatar.attached?
+    tr
       th= User.human_attribute_name(:name)
       td= @user.name
     tr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,10 @@ en:
   time:
     formats:
       default: "%a, %d %b %Y %H:%M"
+  errors:
+    messages:
+      content_type_error: "is not a valid file format"
+      max_size_error: "File size should be greater than %{min_size}"
   activerecord:
     models:
       book: Book
@@ -31,6 +35,7 @@ en:
         updated_at: Updated at
       user:
         name: Name
+        avatar: Icon
         postcode: Postcode
         address: Address
         biography: Biography

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,6 +16,7 @@ ja:
       mini_magick_processing_error: "MiniMagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
       min_size_error: "を%{min_size}以上のサイズにしてください"
       max_size_error: "を%{max_size}以下のサイズにしてください"
+      content_type_error: "のファイル形式が不正です"
   activerecord:
     models:
       book: 書籍
@@ -44,6 +45,7 @@ ja:
         updated_at: 更新日時
       user:
         name: ユーザー名
+        avatar: アイコン
         postcode: 郵便番号
         address: 住所
         biography: 自己紹介

--- a/db/migrate/20190615083952_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20190615083952_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_09_092318) do
+ActiveRecord::Schema.define(version: 2019_06_15_083952) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "books", force: :cascade do |t|
     t.string "title"


### PR DESCRIPTION
ActiveStorageで画像のアップロード機能を追加し、ユーザーがアイコンを設定できるようにしました。

## 概要

- ActiveStorageをインストール
  - ユーザーがアイコンを追加できるようにした
  - バリデーションを追加(最大サイズとファイル形式に制限を加えた)
- 日報/書籍一覧ページ、ユーザー一覧ページにユーザーのアイコンを表示

## 確認方法

- ログイン後、登録情報変更ページからアイコン欄のファイル選択ボタンを押下し画像を選択し更新するとその画像がユーザーのアイコンとして設定される
- ファイルサイズが10MB以上のファイルやcontent_typeが"image/○○"でないファイルはエラーメッセージが表示される
- 書籍一覧や日報一覧に投稿者のアイコンが表示されている

確認よろしくおねがいします:bow:
