### PR TITLE
ユーザーフォロー機能を追加

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -2,12 +2,12 @@ class FriendshipsController < ApplicationController
   def create
     user = User.find(params[:friendship][:followed_id])
     current_user.follow(user)
-    redirect_to user_path(user), notice: "フォローしました"
+    redirect_to user_path(user), notice: t("friendships.flash.create")
   end
 
   def destroy
     user = Friendship.find(params[:id]).followed
     current_user.unfollow(user)
-    redirect_to user_path(user), notice: "フォロー解除しました"
+    redirect_to user_path(user), notice: t("friendships.flash.destroy")
   end
 end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,0 +1,13 @@
+class FriendshipsController < ApplicationController
+  def create
+    user = User.find(params[:friendship][:followed_id])
+    current_user.follow(user)
+    redirect_to user_path(user), notice: "フォローしました"
+  end
+
+  def destroy
+    user = Friendship.find(params[:id]).followed
+    current_user.unfollow(user)
+    redirect_to user_path(user), notice: "フォロー解除しました"
+  end
+end

--- a/app/controllers/users/followers_controller.rb
+++ b/app/controllers/users/followers_controller.rb
@@ -1,0 +1,5 @@
+class Users::FollowersController < ApplicationController
+  def index
+    @followers = User.find(params[:user_id]).followers.with_attached_avatar.order("friendships.updated_at DESC").page(params[:page])
+  end
+end

--- a/app/controllers/users/following_controller.rb
+++ b/app/controllers/users/following_controller.rb
@@ -1,0 +1,5 @@
+class Users::FollowingController < ApplicationController
+  def index
+    @following = User.find(params[:user_id]).following.with_attached_avatar.order("friendships.updated_at DESC").page(params[:page])
+  end
+end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,0 +1,2 @@
+class Friendship < ApplicationRecord
+end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,2 +1,6 @@
 class Friendship < ApplicationRecord
+  belongs_to :follower, class_name: "User"
+  belongs_to :followed, class_name: "User"
+  validates :follower_id, presence: true
+  validates :followed_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,10 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   paginates_per 10
   has_one_attached :avatar
+  has_many :active_relationships, class_name: "Friendship", foreign_key: "follower_id", dependent: :destroy
+  has_many :passive_relationships, class_name: "Friendship", foreign_key: "followed_id", dependent: :destroy
+  has_many :following, through: :active_relationships, source: :followed
+  has_many :followers, through: :passive_relationships
   validate :avatar_validation
 
 
@@ -40,6 +44,18 @@ class User < ApplicationRecord
 
   def self.create_unique_string
     SecureRandom.uuid
+  end
+
+  def follow(other_user)
+    active_relationships.create(followed_id: other_user.id)
+  end
+
+  def unfollow(other_user)
+    active_relationships.find_by(followed_id: other_user.id).destroy
+  end
+
+  def following?(other_user)
+    following.include?(other_user)
   end
 
   private

--- a/app/views/users/_follow.html.slim
+++ b/app/views/users/_follow.html.slim
@@ -1,3 +1,3 @@
 = form_with model: current_user.active_relationships.build, local: true do |f|
   = f.hidden_field :followed_id, value: user.id
-  .actions = f.submit "フォローする"
+  .actions = f.submit t(".action")

--- a/app/views/users/_follow.html.slim
+++ b/app/views/users/_follow.html.slim
@@ -1,0 +1,3 @@
+= form_with model: current_user.active_relationships.build, local: true do |f|
+  = f.hidden_field :followed_id, value: user.id
+  .actions = f.submit "フォローする"

--- a/app/views/users/_follow_form.html.slim
+++ b/app/views/users/_follow_form.html.slim
@@ -1,0 +1,5 @@
+- if user != current_user
+  - if current_user.following?(user)
+    = render partial: "users/unfollow", locals: { user: user }
+  - else
+    = render partial: "users/follow", locals: { user: user }

--- a/app/views/users/_stats.html.slim
+++ b/app/views/users/_stats.html.slim
@@ -1,0 +1,3 @@
+= link_to "Following: #{@user.following.count}", user_following_path(@user)
+| |
+= link_to "Followers: #{@user.followers.count}", user_followers_path(@user)

--- a/app/views/users/_stats.html.slim
+++ b/app/views/users/_stats.html.slim
@@ -1,3 +1,3 @@
-= link_to "Following: #{@user.following.count}", user_following_path(@user)
+= link_to "#{t(".following")}: #{@user.following.count}", user_following_path(@user)
 | |
-= link_to "Followers: #{@user.followers.count}", user_followers_path(@user)
+= link_to "#{t(".followers")}: #{@user.followers.count}", user_followers_path(@user)

--- a/app/views/users/_unfollow.html.slim
+++ b/app/views/users/_unfollow.html.slim
@@ -1,0 +1,2 @@
+= form_with model: current_user.active_relationships.find_by(followed_id: user.id), method: :delete, local: true do |f|
+  .actions = f.submit "フォロー解除"

--- a/app/views/users/_unfollow.html.slim
+++ b/app/views/users/_unfollow.html.slim
@@ -1,2 +1,2 @@
 = form_with model: current_user.active_relationships.find_by(followed_id: user.id), method: :delete, local: true do |f|
-  .actions = f.submit "フォロー解除"
+  .actions = f.submit t(".action")

--- a/app/views/users/followers/index.html.slim
+++ b/app/views/users/followers/index.html.slim
@@ -1,3 +1,3 @@
-h1 フォロワー一覧
+h1 = t(".followers")
 = render partial: "users/user", collection: @followers, as: :user
 = paginate @followers

--- a/app/views/users/followers/index.html.slim
+++ b/app/views/users/followers/index.html.slim
@@ -1,0 +1,3 @@
+h1 フォロワー一覧
+= render partial: "users/user", collection: @followers, as: :user
+= paginate @followers

--- a/app/views/users/following/index.html.slim
+++ b/app/views/users/following/index.html.slim
@@ -1,0 +1,3 @@
+h1 フォロー一覧
+= render partial: "users/user", collection: @following, as: :user
+= paginate @following

--- a/app/views/users/following/index.html.slim
+++ b/app/views/users/following/index.html.slim
@@ -1,3 +1,3 @@
-h1 フォロー一覧
+h1= t('.following')
 = render partial: "users/user", collection: @following, as: :user
 = paginate @following

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -1,4 +1,4 @@
 h1 = t(".users")
-
 .users
   = render partial: "users/user", collection: @users.order(updated_at: :desc), as: :user
+= paginate @users

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,10 +1,14 @@
 h1 = t(".profile")
+= render partial: "users/follow_form", locals: { user: @user }
 
 table
   tbody
     tr
       th = User.human_attribute_name(:avatar)
       td = image_tag(@user.avatar.variant(resize: "50x50")) if @user.avatar.attached?
+    tr
+      th = "フォロー"
+      td = render "users/stats"
     tr
       th= User.human_attribute_name(:name)
       td= @user.name

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -7,7 +7,7 @@ table
       th = User.human_attribute_name(:avatar)
       td = image_tag(@user.avatar.variant(resize: "50x50")) if @user.avatar.attached?
     tr
-      th = "フォロー"
+      th = Friendship.model_name.human
       td = render "users/stats"
     tr
       th= User.human_attribute_name(:name)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,3 +76,20 @@ en:
     show:
       profile: Profile
       edit: Edit User
+    stats:
+      following: Following
+      followers: Followers
+    following:
+      index:
+        following: Following
+    followers:
+      index:
+        followers: Followers
+    follow:
+      action: Follow
+    unfollow:
+      action: Unfollow
+  friendships:
+    flash:
+      create: Followed.
+      destroy: Unfollowed.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,6 +22,7 @@ ja:
       book: 書籍
       report: 日報
       comment: コメント
+      friendship: フォロー
     attributes:
       book:
         id: ID
@@ -86,3 +87,20 @@ ja:
     show:
       profile: プロフィール
       edit: 登録情報変更
+    stats:
+      following: フォロー中
+      followers: フォロワー
+    following:
+      index:
+        following: フォロー一覧
+    followers:
+      index:
+        followers: フォロワー一覧
+    follow:
+      action: フォロー
+    unfollow:
+      action: フォロー解除
+  friendships:
+    flash:
+      create: フォローしました
+      destroy: フォロー解除しました

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,10 @@ Rails.application.routes.draw do
       registrations: "users/registrations",
       confirmations: "users/confirmations",
     }
-    resources :users, only: [:index, :show]
+    resources :users, only: [:index, :show] do
+      get "following" => "users/following#index"
+      get "followers" => "users/followers#index"
+    end
     resources :books
     resources :reports
     resources :comments, except: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     resources :books
     resources :reports
     resources :comments, except: [:index, :show]
+    resources :friendships, only: [:create, :destroy]
   end
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"

--- a/db/migrate/20190620084655_create_friendships.rb
+++ b/db/migrate/20190620084655_create_friendships.rb
@@ -1,0 +1,13 @@
+class CreateFriendships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :friendships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+    add_index :friendships, :follower_id
+    add_index :friendships, :followed_id
+    add_index :friendships, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_15_083952) do
+ActiveRecord::Schema.define(version: 2019_06_20_084655) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -53,6 +53,16 @@ ActiveRecord::Schema.define(version: 2019_06_15_083952) do
     t.integer "user_id", null: false
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "friendships", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_friendships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_friendships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_friendships_on_follower_id"
   end
 
   create_table "reports", force: :cascade do |t|


### PR DESCRIPTION
ユーザーフォロー機能の実装が完了しましたので、確認よろしくおねがいします。

## 概要

- Friendshipモデルを作成、Userモデルとhas_many through関連付けを定義
- Userモデルにユーザーをフォローするメソッドとフォロー解除するメソッドを追加
- ユーザーのプロフィールページにフォローボタンを設置
- ユーザーのプロフィールページにフォロー中とフォロワーのユーザー数を表示
- 18n対応

## 確認方法

- ログイン後、他のユーザーのプロフィールページへ移動してフォローボタンを押すとそのユーザーをフォローすることができ、成功した場合はメッセージが表示される
- フォローしたユーザーのフォロー中のカウントが1増え、フォローされたユーザーのフォロワーのカウントが1増える
- フォロー解除ボタンを押すとメッセージの表示と共にフォロー関係が削除される
- フォロー数/フォロワー数のカウンターからそのユーザーのフォロー/フォロワーであるユーザー一覧が表示される

## スクショ

![image](https://user-images.githubusercontent.com/37890305/60062146-ee14a480-9732-11e9-821d-59e01832c88a.png)

以上です。よろしくお願いします:bow: